### PR TITLE
Please remove atomicmail.io from disposable list (legitimate permanen…

### DIFF
--- a/backend/server/controllers/helpers/disposable_domains.txt
+++ b/backend/server/controllers/helpers/disposable_domains.txt
@@ -493,7 +493,6 @@ asurad.com
 at.hm
 at0mik.org
 atnextmail.com
-atomicmail.io
 attnetwork.com
 aubady.com
 augmentationtechnology.com


### PR DESCRIPTION
…t email service)

Hello,

I'm the Product Manager at Atomic Mail (atomicmail.io). It looks like our domain got caught up in your disposable email blocklist, and I’m hoping to get it removed (and ideally added to allow list).

To give some context: we are a standard, permanent encrypted email provider, not a throwaway mail service. Recently, we were targeted by a coordinated bot attack trying to mass-register accounts. It’s highly likely your automated scrapers (or a user report) caught this spike and flagged our domain.

We’ve shut that down. Here is how we actively prevent abuse on our platform:

We enforce strict rate limits on account creation and auth attempts per IP, along with a mandatory CAPTCHA during registration. We have hard limits on outbound email volume per account to prevent spam runs. We use continuously trained Bayesian models for inbound/outbound filtering (with additional AI-based filtering rolling out soon). Full implementation of DKIM, SPF, and DMARC.
Our Trust & Safety team actively reviews abuse reports and manually bans violators based on our strict zero-tolerance policy: https://atomicmail.io/privacy-policy. We operate in strict compliance with GDPR requirements, ensuring robust data privacy and proper account deletion procedures for all our users. For external validation, I’ve attached a screenshot from Palo Alto Networks URL Filtering confirming our domain holds a clean, 'Low-Risk' Web-based-Email reputation.

Having our domain on this list is currently blocking our real users from registering on third-party sites. Let me know if you need any server logs or further info from my side to verify this.

Thanks for your time and for maintaining this list!
<img width="1710" height="1107" alt="2026-03-20_15-54-19" src="https://github.com/user-attachments/assets/717a8da3-07ca-40b8-a230-e60dc42e68a3" />
